### PR TITLE
Some rephrasing in imports/exports, type assertions, and included non-nullable assertions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ document.getElementById("entry")!.innerText = "...";
 
 In TypeScript, the non-null assertion operator has no runtime semantics, and this proposal would specify it similarly;
 but there is a case for adding non-nullable assertions as a runtime operator instead.
-If the champions come to the conclusion that the latter is preferred, this operator may warrant its own proposal.
+If a runtime operator is preferred, that would likely become an independent proposal.
 
 ### Generics
 


### PR DESCRIPTION
We've already seen proposals within TC39 back away from the postfix `!` operator because TypeScript has been leveraging it (and as a brief aside, I am immensely grateful that those delegates have been considerate of that). For that reason, I think it would be a bad idea *not* to include it in the current text of the proposal.