### PR TITLE
fix link to grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ At runtime, a JavaScript engine ignores them, treating the types as comments.
 
 The aim of this proposal is to enable developers to run programs written in [TypeScript](https://www.typescriptlang.org/), [Flow](https://flow.org/), and other static typing supersets of JavaScript without any need for transpilation, if they stick within a certain reasonably large subset of the language.
 
-[A *tentative* grammar for this proposal is available here.](https://giltayar.github.io/proposal-types-as-comments/grammar.html)
+[A *tentative* grammar for this proposal is available here.](https://tc39.es/proposal-type-annotations/grammar.html)
 
 ## Status
 


### PR DESCRIPTION
The README points to @giltayar's repo — this changes it to what I assume is the correct link