### PR TITLE
Remove incorrect information about impossibility of evolution of JS type system

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,12 +560,8 @@ TC39 has a tradition of programming language design which favors local, sound ch
 By contrast, TypeScript's model -- which has been highly successful for JS developers -- is around non-local, best-effort checks.
 TypeScript-style systems are expensive to check at application startup, and would be redundant every time you run your JavaScript applications.
 
-Additionally, defining a type system to run directly in the browser means that improved type analyses would become breaking changes **for the users of JavaScript applications**, rather than for developers.
-This would [violate goals around web compatibility (i.e. "don't break the web")](https://github.com/tc39/how-we-work/blob/cc47a79340a773876cb03371dc2d46b9d9ce9695/terminology.md#web-compatibilitydont-break-the-web), so type system innovation would become near-impossible.
-Allowing other type systems to analyze code separately provides developers with choice, innovation, and freedom for developers to opt-out of checking at any time.
-
-In contrast, trying to add a full type system to JavaScript would be an enormous multi-year effort that would likely never reach consensus.
-This proposal recognizes that fact, and also recognizes that the community has evolved type systems that it is already happy with.
+Adding a full type system to JavaScript would be an enormous multi-year effort that might never reach consensus.
+This proposal recognizes that fact, and also recognizes that the community has evolved type systems that have become popular.
 
 ### How does this proposal relate to TypeScript?
 


### PR DESCRIPTION
It is possible to build and evolve a type system in such a way that its improvements will not be breaking for users, nor developers of JS applications.

This, of course, depends on the scope of the future type-checker, and many other things. One thing we can know for sure is that whatever type system is ever built in JS, it would certainly be built in such a way that its implementation and evolution [won't break web compatibility](https://github.com/tc39/how-we-work/blob/cc47a79340a773876cb03371dc2d46b9d9ce9695/terminology.md#web-compatibilitydont-break-the-web) because of the explicit commitment by TC39.

However, I am going to show just one example of a possible type system whose introduction and evolution won't result in breaking changes for users or developers, since that should provide enough justification for why these few statements should be removed. Note: this leverages [proposal-built-in-modules](https://github.com/tc39/proposal-built-in-modules) but doesn't have to.

```ts
import type { string, i32, i64, u32, u64, f64, Array, Fn, Tuple, void } from std.es2022.types;
```

Alternatively, it could be written

```ts
// `global` is a special type on which missing types will be looked up (i.e. kind of like globalThis for non-types)
import type * as global from std.es2022.types;
```

Then

```ts
import { deserialize } from std.es2022.types;

type Person = {
  name: string,
  age: u32,
  wealth_dollars: f64,
}

const people: Array<Person> = [];
```

Function definition could be written in a few different ways:

```ts
const load_people: Fn<Tuple<u32, string>, Promise<void>> = async (count, start_name) => {
```

Or, `(a, b, c)` could be a syntax sugar for `Tuple<a,b,c>`:

```ts
const load_people: Fn<(u32, string), Promise<void>> = async (count, start_name) => {
```

Or, more syntax sugar could be applied in case types are part of function signature (but it is the same as `Fn` under the hood):

```ts
const load_people = async (count: u32, start_name: string): void => {
```

In any case, we could end up writing something like this:

```ts
import type * as global from std.es2022.types;
import { deserialize } from std.es2022.types;

type Person = {
  name: string,
  age: u32,
  wealth_dollars: f64,
}

const people: Array<Person> = [];

const load_people = async (count: u32, start_name: string): void => {
  // Note: the result is untyped, since anything can come from an API call
  const result = await fetch(`/api/get_people?count=${count}&starts_with=${start_name}`);
  try {
    const result_unwrapped: Array<Person> = deserialize::<Array<Person>>(await result.json());
    people.push(...result_unwrapped); // This is safe and could be type-checked if Array coming from std.es2022.types contains the type information about .push
  } catch (e) {
    console.warn("Retrieved data has incorrect format");
  }
}

const main = async () => {
  await load_people(20, 'Pe');
  console.log(people);
}

main();
```

Alternatively, if we don't want to use [proposal-built-in-modules](https://github.com/tc39/proposal-built-in-modules) and version it that way (or have `import type * as global`), we can imagine an alternative:

```ts
type global = es2022; // any type of shape es#### will be reserved and contain the globally versioned native types
const { deserialize } = globalThis.es2022.types;
```

If no changes were made to a native type in, e.g. es2023, it will simply be re-exported from the previous version.

This explanation is for the ability to fully version everything within a type system without ever making breaking changes for either users or developers. However, it is unlikely that it is even needed to version it this way. Some basic global primitive types can be agreed upon and stay exactly as they are from the start, and new types could be added to the specification as shown above.

This was just one example of a beginning of a possible type system, which can be introduced and evolve without making any breaking changes, in order to demonstrate the reason for removal of these statements from the proposal.

I have also made 2 other changes in this section in order to make the language more professional and expressing less extreme opinions:

1. "would likely never reach consensus" to "might never reach consensus"
2. "it is already happy with" to "that have become popular"

If you'd like to discuss these 2 changes separately, let me know and I can submit them as a separate PR.