### PR TITLE
Updating HTTP links in README.md to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Therefore similar to the first question of "Does JavaScript need a static type s
 ### How could runtime-checked types be added in future?
 
 It seems unlikely that JavaScript would adopt a pervasive runtime-checked type system due to the runtime performance overhead that it would bring.
-While it's possible that there may have been room for improvement, past efforts such as [TS* (Swamy et al)](http://goto.ucsd.edu/~pvekris/docs/safets.pdf) have shown that runtime type-checking based on annotations adds a non-negligible slowdown.
+While it's possible that there may have been room for improvement, past efforts such as [TS* (Swamy et al)](https://goto.ucsd.edu/~pvekris/docs/safets.pdf) have shown that runtime type-checking based on annotations adds a non-negligible slowdown.
 That is one reason why this proposal endorses purely static types.
 
 If there is a desire to keep language open to later adding runtime-checked types, in addition to the static types proposed here, we could make an explicit syntax reservation in the grammar to support both.
@@ -762,11 +762,11 @@ TC39 has previously discussed [guards](https://web.archive.org/web/2014121407591
 
 Previously, Sam Goto led discussions around an [optional types proposal](https://github.com/samuelgoto/proposal-optional-types) which aimed to unify syntax and semantics across the type-checkers.
 Trying to find agreement across type-checkers, along with defining a sufficient subset in both syntax and semantics meant that there were difficulties with this approach.
-An evolution of this plan was [pluggable types](https://github.com/samuelgoto/proposal-pluggable-types) which was [inspired by Gilad Bracha's ideas on pluggable type systems](http://bracha.org/pluggableTypesPosition.pdf).
+An evolution of this plan was [pluggable types](https://github.com/samuelgoto/proposal-pluggable-types) which was [inspired by Gilad Bracha's ideas on pluggable type systems](https://bracha.org/pluggableTypesPosition.pdf).
 This proposal is extremely similar to the pluggable types proposal, but leans a bit more heavily on the idea of viewing types as comments, and comes at a time with broader adoption of type-checking and a more mature type-checking ecosystem.
 
 The [optional types proposal repository contains links to other prior discussions around types in JavaScript](https://github.com/samuelgoto/proposal-optional-types/blob/master/FAQ.md#tc39-discussions).
 
 ### Relevant discussions elsewhere
 
-[Gilad Bracha](https://en.wikipedia.org/wiki/Gilad_Bracha) has [advocated for pluggable type systems](http://bracha.org/pluggableTypesPosition.pdf).
+[Gilad Bracha](https://en.wikipedia.org/wiki/Gilad_Bracha) has [advocated for pluggable type systems](https://bracha.org/pluggableTypesPosition.pdf).


### PR DESCRIPTION
Checked the links, they are available via HTTPS but not being redirected there.

For your convenience:
- https://goto.ucsd.edu/~pvekris/docs/safets.pdf
- https://bracha.org/pluggableTypesPosition.pdf