### PR TITLE
Update links with changed repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The aim of this proposal is to enable developers to run programs written in [Typ
 - Daniel Rosenwasser (Microsoft)
 - Romulo Cintra (Igalia)
 - Rob Palmer (Bloomberg)
-- ...and a number of contributors, see [history](https://github.com/tc39/proposal-types-as-comments/commits/master).
+- ...and a number of contributors, see [history](https://github.com/tc39/proposal-type-annotations/commits/master).
 
 **Champions:**
 

--- a/site/src/grammar-input.html
+++ b/site/src/grammar-input.html
@@ -2,7 +2,7 @@
 title: Types as Comments Tentative Grammar
 stage: 0
 status: proposal
-location: https://github.com/tc39/proposal-types-as-comments/
+location: https://github.com/tc39/proposal-type-annotations/
 contributors: Anders Hejlsberg, Daniel Rosenwasser
 copyright: false
 </pre>
@@ -14,7 +14,7 @@ It is not a comprehensive specification and it does not contain any formal seman
 Just as implementations typically do not provide runtime semantics for comments, the type syntax outlined here should not introduce noticeable runtime semantics.
 </p>
 <p>
-Any issues with the grammar in this document should be <a href="https://github.com/tc39/proposal-types-as-comments/">reported on the proposal repository</a>.
+Any issues with the grammar in this document should be <a href="https://github.com/tc39/proposal-type-annotations/">reported on the proposal repository</a>.
 </p>
 </aside>
 

--- a/site/src/site.jsx
+++ b/site/src/site.jsx
@@ -194,7 +194,7 @@ const Page = () => <html lang="en">
         </Entry>
 
         <Entry title="What does the grammar look like?">
-          <p>You can read the <a href="https://tc39.github.io/proposal-types-as-comments/grammar.html">grammar spec here</a> and <a href="https://github.com/tc39/proposal-types-as-comments/blob/master/syntax/grammar-ideas.md">notes for implementation</a> inside the repo.</p>
+          <p>You can read the <a href="https://tc39.github.io/proposal-type-annotations/grammar.html">grammar spec here</a> and <a href="https://github.com/tc39/proposal-type-annotations/blob/master/syntax/grammar-ideas.md">notes for implementation</a> inside the repo.</p>
         </Entry>
       </FAQ>
 
@@ -225,17 +225,17 @@ const Page = () => <html lang="en">
       <h2>Links</h2>
       <aside>This page is a simpler overview of Types as Comments, to learn more about the proposal consult the GitHub repo.</aside>
       <Split>
-        <a className="button" href="https://github.com/tc39/proposal-types-as-comments#motivation">
+        <a className="button" href="https://github.com/tc39/proposal-type-annotations#motivation">
           <h5>Motivations</h5>
           <p>How does this proposal improve the JavaScript ecosystem as a whole?</p>
         </a>
 
-        <a className="button" href="https://github.com/tc39/proposal-types-as-comments#proposal">
+        <a className="button" href="https://github.com/tc39/proposal-type-annotations#proposal">
           <h5>Supported Syntax</h5>
           <p>From types definitions to class properties, see all the proposed supported type-level syntax.</p>
         </a>
 
-        <a className="button" href="https://github.com/tc39/proposal-types-as-comments#FAQ">
+        <a className="button" href="https://github.com/tc39/proposal-type-annotations#FAQ">
           <h5>Frequently Asked Questions</h5>
           <p>How does this proposal relate to TypeScript or Flow support? and many other questions.</p>
         </a>

--- a/syntax/grammar.md
+++ b/syntax/grammar.md
@@ -1,1 +1,1 @@
-[A *tentative* grammar for this proposal is available here.](https://tc39.github.io/proposal-types-as-comments/grammar.html)
+[A *tentative* grammar for this proposal is available here.](https://tc39.github.io/proposal-type-annotations/grammar.html)


### PR DESCRIPTION
The name of this repo was changed from `proposal-types-as-comments` to `proposal-type-annotations`.

So I updated links with changed repository name.   