### PR TITLE
Skipping transpilation won't discourage minifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ It remains a best practice to perform an ahead-of-time optimization step on code
 
 Specifically, note that [the TypeScript compiler `tsc` does not have a built-in option to minify](https://github.com/microsoft/TypeScript/issues/8).  Allowing TypeScript users to skip `tsc` during development will not inherently encourage users to skip a minification step, since that would have required separate action in any case.
 
-Babel is another popular transpiler for TypeScript, Flow, and Hegel. Babel's `preset-typescript` and `preset-flow` transpilers do not minify. In Babel, minification requires a separate step. Allowing Babel users to omit `preset-typescript` will not encourage users to skip minification.
+Babel is another popular transpiler for TypeScript, Flow, and Hegel. Babel's `preset-typescript` and `preset-flow` transpilers do not minify. In Babel, minification requires a separate step (usually performed by a bundler). Allowing Babel users to omit `preset-typescript` will not encourage users to skip minification.
 
 In this proposal, type annotations are treated as comments. Making comments more useful and easier to use is an appropriate evolution for JavaScript, even when we expect developers to remove comments and type annotations via minification.
 

--- a/README.md
+++ b/README.md
@@ -688,6 +688,12 @@ However this situation already exists.
 Today, many users omit a build step and ship large amounts of comments and other extraneous information, e.g. unminified code.
 It remains a best practice to perform an ahead-of-time optimization step on code destined for production if the use-case is performance-sensitive.
 
+Specifically, note that [the TypeScript compiler `tsc` does not have a built-in option to minify](https://github.com/microsoft/TypeScript/issues/8).  Allowing TypeScript users to skip `tsc` during development will not inherently encourage users to skip a minification step, since that would have required separate action in any case.
+
+Babel is another popular transpiler for TypeScript, Flow, and Hegel. Babel's `preset-typescript` and `preset-flow` transpilers do not minify. In Babel, minification requires a separate step. Allowing Babel users to omit `preset-typescript` will not encourage users to skip minification.
+
+In this proposal, type annotations are treated as comments. Making comments more useful and easier to use is an appropriate evolution for JavaScript, even when we expect developers to remove comments and type annotations via minification.
+
 ### Are unchecked types a footgun?
 
 This proposal introduces type annotations that are explicitly **not** checked at runtime.

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ However this situation already exists.
 Today, many users omit a build step and ship large amounts of comments and other extraneous information, e.g. unminified code.
 It remains a best practice to perform an ahead-of-time optimization step on code destined for production if the use-case is performance-sensitive.
 
-Specifically, note that [the TypeScript compiler `tsc` does not have a built-in option to minify](https://github.com/microsoft/TypeScript/issues/8).  Allowing TypeScript users to skip `tsc` during development will not inherently encourage users to skip a minification step, since that would have required separate action in any case.
+Specifically, note that [the TypeScript compiler `tsc` does not have a built-in option to minify](https://github.com/microsoft/TypeScript/issues/8).  Allowing TypeScript users to skip `tsc` during development will not inherently encourage users to skip a minification step, since minifying TypeScript would have required a separate action in any case.
 
 Babel is another popular transpiler for TypeScript, Flow, and Hegel. Babel's `preset-typescript` and `preset-flow` transpilers do not minify. In Babel, minification requires a separate step (usually performed by a bundler). Allowing Babel users to omit `preset-typescript` will not encourage users to skip minification.
 


### PR DESCRIPTION
Here and elsewhere, we've seen arguments that this proposal will encourage users to skip minifying their code. (I think the argument is that since users are required to transpile, that will also encourage them to minify.)

The FAQ has an entry on this, but I wanted to elaborate on it, by pointing out that no popular transpiler minifies by default. Minification always requires a separate, non-default step.