### PR TITLE
[grammar] Use a different syntax for type instantiation

### DIFF
--- a/site/src/grammar-input.html
+++ b/site/src/grammar-input.html
@@ -157,7 +157,7 @@ AsyncMethod :
     `async`  [no LineTerminator here]  ClassElementName  `?`?  TypeParameters?  `(`  UniqueFormalParameters  `)`  TypeAnnotation?  `{`  AsyncFunctionBody  `}`
 
 CoverCallExpressionAndAsyncArrowHead :
-    MemberExpression  TypeParameters?  Arguments  TypeAnnotation?
+    MemberExpression ApplicationTypeArguments?  Arguments  TypeAnnotation?
 
 AsyncArrowHead :
     `async`  [no LineTerminator here]  TypeParameters?  ArrowFormalParameters
@@ -183,6 +183,9 @@ ImportSpecifier :
 
 TypeArguments :
     AngleBracketedTokens
+
+ApplicationTypeArguments :
+    `::<` TypeArgumentList `>`
 
 TypeDeclaration :
     `type`  BindingIdentifier  TypeParameters?  `=`  Type


### PR DESCRIPTION
For the draft grammar, switch to using `f::<T>(arg)` syntax instead of `f<T>(arg)` syntax. Since this is in an expression context (instead of a type context), this explicit type instantiation is ambiguous with the `<` operator. This feedback came up during the March 2023 TC39 meeting.

I believe the ambiguity would come up with an example like this:

```
x < 4
5 > (y)
```

This can be parsed as

```
x < 4
^
MemberExpression
  ^^^
  TypeParamters
5 > (y)
^^^
TypeParameters
    ^^^
    Arguments
```

Or as RelationalExpressions.