### PR TITLE
State of JS 2023 -- also the most missing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The strong demand for ergonomic type annotation syntax has led to forks of JavaS
 
 ### Community Usage and Demand
 
-_Static Typing_ was the most requested language feature in the [_State of JS_ survey](https://stateofjs.com) in [2020](https://2020.stateofjs.com/en-US/opinions/missing_from_js/), [2021](https://2021.stateofjs.com/en-US/opinions/#currently_missing_from_js_wins) and [2022](https://2022.stateofjs.com/en-US/opinions/#top_currently_missing_from_js).
+_Static Typing_ was the most requested language feature in the [_State of JS_ survey](https://stateofjs.com) in [2020](https://2020.stateofjs.com/en-US/opinions/missing_from_js/), [2021](https://2021.stateofjs.com/en-US/opinions/#currently_missing_from_js_wins), [2022](https://2022.stateofjs.com/en-US/opinions/#top_currently_missing_from_js) and [2023](https://2023.stateofjs.com/en-US/usage/#top_currently_missing_from_js).
 
 ![missing-features-js](https://user-images.githubusercontent.com/6939381/143012138-96b93204-c456-4ab5-bb63-2648187ab8a7.png)
 


### PR DESCRIPTION
Another year has passed without static types ._.