### PR TITLE
fix: add root link to GitHub repo in footer area

### DIFF
--- a/site/src/site.jsx
+++ b/site/src/site.jsx
@@ -223,7 +223,7 @@ const Page = () => <html lang="en">
       </FAQ>
 
       <h2>Links</h2>
-      <aside>This page is a simpler overview of Types as Comments, to learn more about the proposal consult the GitHub repo.</aside>
+      <aside>This page is a simpler overview of Types as Comments, to learn more about the proposal consult the <a href="https://github.com/tc39/proposal-type-annotations">GitHub repo</a>.</aside>
       <Split>
         <a className="button" href="https://github.com/tc39/proposal-type-annotations#motivation">
           <h5>Motivations</h5>


### PR DESCRIPTION
The site doesn't have any non-hash link to this repository yet. And the footer references _"the GitHub repo"_ without linking. So I went ahead and turned that into a link.