### PR TITLE
feat: fix accessibility bugs and add dark mode

### DIFF
--- a/site/src/components.jsx
+++ b/site/src/components.jsx
@@ -37,7 +37,7 @@ export const SplitReverse = (props) => (
 /** @param {{ name: string, body: string }} props  */
 export const TwoThirdsHeading = (props) => (
     <div className="section two-thirds">
-       <div className="one"><h4>{props.name}</h4></div>
+       <div className="one"><h2 className="h2-inline">{props.name}</h2></div>
        <p className="two">{props.body}</p>
    </div>  
 )
@@ -64,7 +64,7 @@ export const setupShikiTwoslash = async (config) => {
 export const Code = (props) => {
     if (typeof props.children !== "string") throw new Error("Code components need to be strings, not more components.")
 
-    const Title = props.title ? () => <h4 className="code-title">{props.title}</h4> : () => null
+    const Title = props.title ? () => <strong className="code-title">{props.title}</strong> : () => null
     const Subtitle = props.after ? () => <p className="code-after">{props.after}</p> : () => null
     const Suffix = props.emoji ? () => <span className="emoji" role="img" aria-label={props.emojiName}>{props.emoji}</span> : () => null
     const code = dedentString(props.children)

--- a/site/src/shiki-theme.json
+++ b/site/src/shiki-theme.json
@@ -1,0 +1,511 @@
+{
+  "colors": {
+    "activityBar.activeBorder": "#f9826c",
+    "activityBar.background": "#fff",
+    "activityBar.border": "#e1e4e8",
+    "activityBar.foreground": "#2f363d",
+    "activityBar.inactiveForeground": "#959da5",
+    "activityBarBadge.background": "#2188ff",
+    "activityBarBadge.foreground": "#fff",
+    "badge.background": "#dbedff",
+    "badge.foreground": "#005cc5",
+    "breadcrumb.activeSelectionForeground": "#586069",
+    "breadcrumb.focusForeground": "#2f363d",
+    "breadcrumb.foreground": "#6a737d",
+    "breadcrumbPicker.background": "#fafbfc",
+    "button.background": "#159739",
+    "button.foreground": "#fff",
+    "button.hoverBackground": "#138934",
+    "button.secondaryBackground": "#e1e4e8",
+    "button.secondaryForeground": "#1b1f23",
+    "button.secondaryHoverBackground": "#d1d5da",
+    "checkbox.background": "#fafbfc",
+    "checkbox.border": "#d1d5da",
+    "debugToolBar.background": "#fff",
+    "descriptionForeground": "#6a737d",
+    "diffEditor.insertedTextBackground": "#34d05822",
+    "diffEditor.removedTextBackground": "#d73a4922",
+    "dropdown.background": "#fafbfc",
+    "dropdown.border": "#e1e4e8",
+    "dropdown.foreground": "#2f363d",
+    "dropdown.listBackground": "#fff",
+    "editor.background": "#fff",
+    "editor.findMatchBackground": "#ffdf5d",
+    "editor.findMatchHighlightBackground": "#ffdf5d66",
+    "editor.focusedStackFrameHighlightBackground": "#28a74525",
+    "editor.foldBackground": "#d1d5da11",
+    "editor.foreground": "#24292e",
+    "editor.inactiveSelectionBackground": "#0366d611",
+    "editor.lineHighlightBackground": "#f6f8fa",
+    "editor.linkedEditingBackground": "#0366d611",
+    "editor.selectionBackground": "#0366d625",
+    "editor.selectionHighlightBackground": "#34d05840",
+    "editor.selectionHighlightBorder": "#34d05800",
+    "editor.stackFrameHighlightBackground": "#ffd33d33",
+    "editor.wordHighlightBackground": "#34d05800",
+    "editor.wordHighlightBorder": "#24943e99",
+    "editor.wordHighlightStrongBackground": "#34d05800",
+    "editor.wordHighlightStrongBorder": "#24943e50",
+    "editorBracketHighlight.foreground1": "#005cc5",
+    "editorBracketHighlight.foreground2": "#a15c1b",
+    "editorBracketHighlight.foreground3": "#5a32a3",
+    "editorBracketHighlight.foreground4": "#005cc5",
+    "editorBracketHighlight.foreground5": "#a15c1b",
+    "editorBracketHighlight.foreground6": "#5a32a3",
+    "editorBracketMatch.background": "#34d05840",
+    "editorBracketMatch.border": "#34d05800",
+    "editorCursor.foreground": "#044289",
+    "editorError.foreground": "#cb2431",
+    "editorGroup.border": "#e1e4e8",
+    "editorGroupHeader.tabsBackground": "#f6f8fa",
+    "editorGroupHeader.tabsBorder": "#e1e4e8",
+    "editorGutter.addedBackground": "#28a745",
+    "editorGutter.deletedBackground": "#cf2a3b",
+    "editorGutter.modifiedBackground": "#2188ff",
+    "editorIndentGuide.activeBackground": "#d7dbe0",
+    "editorIndentGuide.background": "#eff2f6",
+    "editorLineNumber.activeForeground": "#24292e",
+    "editorLineNumber.foreground": "#1b1f234d",
+    "editorOverviewRuler.border": "#fff",
+    "editorWarning.foreground": "#f9c513",
+    "editorWhitespace.foreground": "#d1d5da",
+    "editorWidget.background": "#f6f8fa",
+    "errorForeground": "#cb2431",
+    "focusBorder": "#2188ff",
+    "foreground": "#444d56",
+    "gitDecoration.addedResourceForeground": "#28a745",
+    "gitDecoration.conflictingResourceForeground": "#a15c1b",
+    "gitDecoration.deletedResourceForeground": "#cf2a3b",
+    "gitDecoration.ignoredResourceForeground": "#959da5",
+    "gitDecoration.modifiedResourceForeground": "#005cc5",
+    "gitDecoration.submoduleResourceForeground": "#959da5",
+    "gitDecoration.untrackedResourceForeground": "#28a745",
+    "input.background": "#fafbfc",
+    "input.border": "#e1e4e8",
+    "input.foreground": "#2f363d",
+    "input.placeholderForeground": "#959da5",
+    "list.activeSelectionBackground": "#e2e5e9",
+    "list.activeSelectionForeground": "#2f363d",
+    "list.focusBackground": "#cce5ff",
+    "list.hoverBackground": "#ebf0f4",
+    "list.hoverForeground": "#2f363d",
+    "list.inactiveFocusBackground": "#dbedff",
+    "list.inactiveSelectionBackground": "#e8eaed",
+    "list.inactiveSelectionForeground": "#2f363d",
+    "notificationCenterHeader.background": "#e1e4e8",
+    "notificationCenterHeader.foreground": "#6a737d",
+    "notifications.background": "#fafbfc",
+    "notifications.border": "#e1e4e8",
+    "notifications.foreground": "#2f363d",
+    "notificationsErrorIcon.foreground": "#cf2a3b",
+    "notificationsInfoIcon.foreground": "#005cc5",
+    "notificationsWarningIcon.foreground": "#a15c1b",
+    "panel.background": "#f6f8fa",
+    "panel.border": "#e1e4e8",
+    "panelInput.border": "#e1e4e8",
+    "panelTitle.activeBorder": "#f9826c",
+    "panelTitle.activeForeground": "#2f363d",
+    "panelTitle.inactiveForeground": "#6a737d",
+    "pickerGroup.border": "#e1e4e8",
+    "pickerGroup.foreground": "#2f363d",
+    "progressBar.background": "#2188ff",
+    "quickInput.background": "#fafbfc",
+    "quickInput.foreground": "#2f363d",
+    "scrollbar.shadow": "#6a737d33",
+    "scrollbarSlider.activeBackground": "#959da588",
+    "scrollbarSlider.background": "#959da533",
+    "scrollbarSlider.hoverBackground": "#959da544",
+    "settings.headerForeground": "#2f363d",
+    "settings.modifiedItemIndicator": "#2188ff",
+    "sideBar.background": "#f6f8fa",
+    "sideBar.border": "#e1e4e8",
+    "sideBar.foreground": "#586069",
+    "sideBarSectionHeader.background": "#f6f8fa",
+    "sideBarSectionHeader.border": "#e1e4e8",
+    "sideBarSectionHeader.foreground": "#2f363d",
+    "sideBarTitle.foreground": "#2f363d",
+    "statusBar.background": "#fff",
+    "statusBar.border": "#e1e4e8",
+    "statusBar.debuggingBackground": "#f9826c",
+    "statusBar.debuggingForeground": "#fff",
+    "statusBar.foreground": "#586069",
+    "statusBar.noFolderBackground": "#fff",
+    "statusBarItem.prominentBackground": "#e8eaed",
+    "statusBarItem.remoteBackground": "#fff",
+    "statusBarItem.remoteForeground": "#586069",
+    "tab.activeBackground": "#fff",
+    "tab.activeBorder": "#fff",
+    "tab.activeBorderTop": "#f9826c",
+    "tab.activeForeground": "#2f363d",
+    "tab.border": "#e1e4e8",
+    "tab.hoverBackground": "#fff",
+    "tab.inactiveBackground": "#f6f8fa",
+    "tab.inactiveForeground": "#6a737d",
+    "tab.unfocusedActiveBorder": "#fff",
+    "tab.unfocusedActiveBorderTop": "#e1e4e8",
+    "tab.unfocusedHoverBackground": "#fff",
+    "terminal.ansiBlack": "#24292e",
+    "terminal.ansiBlue": "#0366d6",
+    "terminal.ansiBrightBlack": "#959da5",
+    "terminal.ansiBrightBlue": "#005cc5",
+    "terminal.ansiBrightCyan": "#3192aa",
+    "terminal.ansiBrightGreen": "#22863a",
+    "terminal.ansiBrightMagenta": "#5a32a3",
+    "terminal.ansiBrightRed": "#cb2431",
+    "terminal.ansiBrightWhite": "#d1d5da",
+    "terminal.ansiBrightYellow": "#b08800",
+    "terminal.ansiCyan": "#1b7c83",
+    "terminal.ansiGreen": "#28a745",
+    "terminal.ansiMagenta": "#5a32a3",
+    "terminal.ansiRed": "#cf2a3b",
+    "terminal.ansiWhite": "#6a737d",
+    "terminal.ansiYellow": "#dbab09",
+    "terminal.foreground": "#586069",
+    "terminal.tab.activeBorder": "#f9826c",
+    "terminalCursor.background": "#d1d5da",
+    "terminalCursor.foreground": "#005cc5",
+    "textBlockQuote.background": "#fafbfc",
+    "textBlockQuote.border": "#e1e4e8",
+    "textCodeBlock.background": "#f6f8fa",
+    "textLink.activeForeground": "#005cc5",
+    "textLink.foreground": "#0366d6",
+    "textPreformat.foreground": "#586069",
+    "textSeparator.foreground": "#d1d5da",
+    "titleBar.activeBackground": "#fff",
+    "titleBar.activeForeground": "#2f363d",
+    "titleBar.border": "#e1e4e8",
+    "titleBar.inactiveBackground": "#f6f8fa",
+    "titleBar.inactiveForeground": "#6a737d",
+    "tree.indentGuidesStroke": "#e1e4e8",
+    "welcomePage.buttonBackground": "#f6f8fa",
+    "welcomePage.buttonHoverBackground": "#e1e4e8"
+  },
+  "displayName": "Types as Comments Light",
+  "name": "types-as-comments-light",
+  "semanticHighlighting": true,
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment", "string.comment"],
+      "settings": {
+        "foreground": "#6b6b6b"
+      }
+    },
+    {
+      "scope": [
+        "constant",
+        "entity.name.constant",
+        "variable.other.constant",
+        "variable.other.enummember",
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": ["entity", "entity.name"],
+      "settings": {
+        "foreground": "#6f42c1"
+      }
+    },
+    {
+      "scope": "variable.parameter.function",
+      "settings": {
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#cf2a3b"
+      }
+    },
+    {
+      "scope": ["storage", "storage.type"],
+      "settings": {
+        "foreground": "#cf2a3b"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier.package",
+        "storage.modifier.import",
+        "storage.type.java"
+      ],
+      "settings": {
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string",
+        "string punctuation.section.embedded source"
+      ],
+      "settings": {
+        "foreground": "#032f62"
+      }
+    },
+    {
+      "scope": "support",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.property-name",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "variable",
+      "settings": {
+        "foreground": "#a15c1b"
+      }
+    },
+    {
+      "scope": "variable.other",
+      "settings": {
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": "invalid.broken",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "invalid.illegal",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "carriage-return",
+      "settings": {
+        "background": "#cf2a3b",
+        "content": "^M",
+        "fontStyle": "italic underline",
+        "foreground": "#fafbfc"
+      }
+    },
+    {
+      "scope": "message.error",
+      "settings": {
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "string variable",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": ["source.regexp", "string.regexp"],
+      "settings": {
+        "foreground": "#032f62"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp.character-class",
+        "string.regexp constant.character.escape",
+        "string.regexp source.ruby.embedded",
+        "string.regexp string.regexp.arbitrary-repitition"
+      ],
+      "settings": {
+        "foreground": "#032f62"
+      }
+    },
+    {
+      "scope": "string.regexp constant.character.escape",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": "support.constant",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "support.variable",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.module-reference",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#a15c1b"
+      }
+    },
+    {
+      "scope": ["markup.heading", "markup.heading entity.name"],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": ["markup.underline"],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": ["markup.strikethrough"],
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": [
+        "markup.deleted",
+        "meta.diff.header.from-file",
+        "punctuation.definition.deleted"
+      ],
+      "settings": {
+        "background": "#ffeef0",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": [
+        "markup.inserted",
+        "meta.diff.header.to-file",
+        "punctuation.definition.inserted"
+      ],
+      "settings": {
+        "background": "#f0fff4",
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": ["markup.changed", "punctuation.definition.changed"],
+      "settings": {
+        "background": "#ffebda",
+        "foreground": "#a15c1b"
+      }
+    },
+    {
+      "scope": ["markup.ignored", "markup.untracked"],
+      "settings": {
+        "background": "#005cc5",
+        "foreground": "#f6f8fa"
+      }
+    },
+    {
+      "scope": "meta.diff.range",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#6f42c1"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.separator",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.output",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": [
+        "brackethighlighter.tag",
+        "brackethighlighter.curly",
+        "brackethighlighter.round",
+        "brackethighlighter.square",
+        "brackethighlighter.angle",
+        "brackethighlighter.quote"
+      ],
+      "settings": {
+        "foreground": "#586069"
+      }
+    },
+    {
+      "scope": "brackethighlighter.unmatched",
+      "settings": {
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": ["constant.other.reference.link", "string.other.link"],
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#032f62"
+      }
+    }
+  ],
+  "type": "light"
+}

--- a/site/src/site.jsx
+++ b/site/src/site.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { writeFileSync } from "fs"
 import { DevWebSocket, Entry, FAQ, Header, setupShikiTwoslash, Split, Code, TwoThirdsHeading, CenterOneColumn } from "./components.jsx"
+import shikiTheme from './shiki-theme.json';
 
 const Page = () => <html lang="en">
     <head>
@@ -104,14 +105,14 @@ const Page = () => <html lang="en">
       <Split>
         
         <article>
-          <h4>JavaScript and TypeScript Users</h4>
+          <h3>JavaScript and TypeScript Users</h3>
           <p>Less need for source code transformation in modern JavaScript projects.</p>
           <p>Cleaner and more powerful syntax than JSDoc comments.</p>
           <p>Pasting typed code into consoles and REPLs just works.</p>
         </article>
 
         <article>
-          <h4>Tool Makers</h4>
+          <h3>Tool Makers</h3>
           <p>New experimental type systems can be built using the ignored syntax space.</p>
           <p>Existing JavaScript tools can:</p>
           <ul>
@@ -123,7 +124,7 @@ const Page = () => <html lang="en">
         </article>
 
         <article>
-          <h4>Engine Maintainers</h4>
+          <h3>Engine Maintainers</h3>
           <p>Browser engines do not pay any type-checking cost at runtime.</p>
           <p>Engine maintainers avoid the burden of parser upgrades as each type system evolves.</p>
         </article>
@@ -226,17 +227,17 @@ const Page = () => <html lang="en">
       <aside>This page is a simpler overview of Types as Comments, to learn more about the proposal consult the GitHub repo.</aside>
       <Split>
         <a className="button" href="https://github.com/tc39/proposal-type-annotations#motivation">
-          <h5>Motivations</h5>
+          <h3>Motivations</h3>
           <p>How does this proposal improve the JavaScript ecosystem as a whole?</p>
         </a>
 
         <a className="button" href="https://github.com/tc39/proposal-type-annotations#proposal">
-          <h5>Supported Syntax</h5>
+          <h3>Supported Syntax</h3>
           <p>From types definitions to class properties, see all the proposed supported type-level syntax.</p>
         </a>
 
         <a className="button" href="https://github.com/tc39/proposal-type-annotations#FAQ">
-          <h5>Frequently Asked Questions</h5>
+          <h3>Frequently Asked Questions</h3>
           <p>How does this proposal relate to TypeScript or Flow support? and many other questions.</p>
         </a>
       </Split>
@@ -247,7 +248,8 @@ const Page = () => <html lang="en">
 
 // This code is evaluated during the build and triggers saving the .html
 const go = async () => {
-  await setupShikiTwoslash({ theme: "github-light"})
+  // @ts-expect-error - aligning .json types to IShikiTheme
+  await setupShikiTwoslash({ theme: shikiTheme })
   const html = ReactDOMServer.renderToStaticMarkup(<Page />)
   writeFileSync("./out/index.html", html)
 }

--- a/site/src/style.scss
+++ b/site/src/style.scss
@@ -8,12 +8,56 @@
   src: url("./assets/PT_Serif/PTSerif-Regular.ttf") format("ttf");
 }
 
-$sans: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+$sans: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+  Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 $serif: "PT Serif", Georgia, "Times New Roman", Times, serif;
 $one-col-width-min: 879px;
 
+:root {
+  color-scheme: light;
+
+  // Shared colors palette
+  --color-gray-dark-emphasized: #222;
+  --color-gray-dark: #444;
+  --color-gray-dark-mid: #706b67;
+  --color-gray-dark-lighter: #ada59e;
+  --color-gray-light: #ddd;
+  --color-gray-light-emphasized: #eee;
+  --color-tan-dark: #292726;
+  --color-tan-dark-emphasized: #5a504a;
+  --color-tan-light: #f9eee6;
+  --color-tan-light-emphasized: #f5dac2;
+  --color-orange-mid: #fc7c00;
+  --color-orange-dark: #a15c1b;
+
+  // Light mode palette usage (default)
+  --color-background-base: var(--color-tan-light);
+  --color-border: var(--color-gray-dark);
+  --color-comment: var(--color-gray-dark-mid);
+  --color-emphasis: var(--color-orange-mid);
+  --color-foreground-bold: black;
+  --color-foreground-emphasized: var(--color-gray-dark-emphasized);
+  --color-foreground-orange: var(--color-orange-dark);
+  --color-foreground-tan-emphasized: var(--color-tan-light-emphasized);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+
+    // Dark mode palette usage
+    --color-background-base: var(--color-tan-dark);
+    --color-border: var(--color-gray-light);
+    --color-comment: var(--color-gray-dark-lighter);
+    --color-foreground-bold: white;
+    --color-foreground-emphasized: var(--color-gray-light-emphasized);
+    --color-foreground-orange: var(--color-orange-mid);
+    --color-foreground-tan-emphasized: var(--color-tan-dark-emphasized);
+  }
+}
+
 html {
-  background: #f9eee6;
+  background: var(--color-background-base);
 }
 
 body {
@@ -29,7 +73,7 @@ body {
 }
 
 .section {
-  margin-bottom: 2rem;  
+  margin-bottom: 2rem;
 
   ul {
     padding-left: 0.6rem;
@@ -42,7 +86,7 @@ code {
 }
 
 hr {
-  background: #fc7c00;
+  background: var(--color-orange-mid);
   border: none;
   height: 3px;
 }
@@ -90,12 +134,19 @@ hr {
 
 .two-thirds {
   font: $sans;
-  
+  padding-bottom: 1.33em;
+
   p {
     font-size: 1.2rem;
     line-height: 1.8rem;
   }
-  
+
+  .one {
+    font-family: $sans;
+    font-size: 0.66em;
+    font-weight: bold;
+  }
+
   @media (min-width: $one-col-width-min) {
     display: flex;
     .one {
@@ -116,7 +167,7 @@ hr {
 .one-column-center {
   @media (min-width: $one-col-width-min) {
     width: 50%;
-    margin: 0 auto    ;
+    margin: 0 auto;
   }
 }
 
@@ -128,7 +179,7 @@ h4 {
   text-align: center;
 }
 
-h2 {
+h2:not(.h2-inline) {
   margin-top: 120px;
 }
 
@@ -140,7 +191,7 @@ aside {
   margin-bottom: 50px;
 
   a {
-    color: black
+    color: var(--color-foreground-bold);
   }
 }
 
@@ -148,32 +199,38 @@ h1 {
   padding-top: 4px;
   font-size: 1rem;
   em {
-    color: #706b67;
+    color: var(--color-comment);
   }
 }
 
-h2::after {
+h2:not(.h2-inline)::after {
   content: "";
   margin: 20px auto;
   display: block;
   max-width: 400px;
   height: 2px;
-  background: #fc7c00;
+  background: var(--color-orange-mid);
+}
+
+h3 {
+  font-size: 1rem;
+  margin-block-start: 1.33em;
+  margin-block-end: 1.33em;
 }
 
 .question {
   font-family: $sans;
-  color: #d17924;
+  color: var(--color-foreground-orange);
 
   text-align: center;
   font-size: 1.2rem;
 }
 
 p > code {
-  background-color: #f5dac2;
+  background-color: var(--color-foreground-tan-emphasized);
   display: inline-block;
   border-radius: 4px;
-  color: #222;
+  color: var(--color-foreground-emphasized);
 }
 
 .faq {
@@ -216,39 +273,45 @@ p > code {
   }
 
   div > * {
-    margin:0;
+    margin: 0;
     text-align: left;
     font-weight: normal;
     font-size: 1.3rem;
-    font-family: $sans; 
+    font-family: $sans;
   }
 }
 
 a.button {
-  color: black;
-  background-color: #FC7C0020;
+  color: var(--color-foreground-bold);
+  background-color: #fc7c0020;
   text-decoration: none;
   padding: 10px;
-  margin-bottom:  20px;
-  border-left: 2px solid #FC7C00;
+  margin-bottom: 20px;
+  border-left: 2px solid var(--color-emphasis);
   font-size: 1rem;
-  h5 {
+  h3 {
     font-size: 1.1rem;
-    margin: 0.4rem 0 ;
+    margin: 0.4rem 0;
+    text-align: left;
   }
   p {
     margin: 0;
   }
   &:hover {
-    background-color: #FC7C0010;
+    background-color: #fc7c0010;
   }
+}
+
+.primary-code-samples {
+  padding-top: 1.33em;
 }
 
 .code-sample {
   position: relative;
 
-  h4.code-title {
-    margin-bottom: -8px;
+  strong.code-title {
+    padding-top: 1.33em;
+    font-family: $sans;
     text-align: left;
   }
 
@@ -257,12 +320,11 @@ a.button {
     bottom: -8px;
     right: 0px;
   }
-
-} 
+}
 .code-after {
+  color: var(--color-comment);
   margin-top: -2.2rem;
   text-align: right;
-  opacity: 0.5;
 }
 
 /*  Start of Shiki Twoslash CSS:
@@ -280,17 +342,15 @@ Code blocks structurally look like:
 
 pre {
   /* In theory shiki will overwrite these, but this is to make sure there are defaults regardless */
-  background-color: #F9EEE6 !important;
-  color: black;
-
-  /* Give it some space to breathe */
-  padding: 12px 0 ;
+  background-color: var(--color-background-base) !important;
+  color: var(--color-foreground-bold);
 
   /* All code samples get a grey border, twoslash ones get a different color */
-  border-left: 1px solid #444;
-  border-bottom: 1px solid #444;
+  border-left: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 
   margin-bottom: 3rem;
+  margin-block-start: 0.5rem;
 
   /* Important to allow the code to move horizontally; */
   overflow-x: auto;
@@ -323,7 +383,6 @@ pre.shiki .language-id {
   display: none;
 }
 
-
 /** When you mouse over the pre, show the underlines */
 pre.twoslash:hover data-lsp {
   border-color: #747474;
@@ -347,7 +406,11 @@ pre.twoslash data-lsp:hover::before {
 }
 
 pre .code-container {
+  background: var(--color-tan-light);
   overflow: auto;
+
+  /* Give it some space to breathe */
+  padding: 12px 0;
 }
 
 /* Respect no animations */
@@ -389,7 +452,6 @@ pre .query {
   padding-right: 1rem;
 }
 
-
 /* In order to have the 'popped out' style design and to not break the layout
   /* we need to place a fake and un-selectable copy of the error which _isn't_ broken out
   /* behind the actual error message.
@@ -414,7 +476,7 @@ pre .error {
   /* Give the space to the error code */
   display: flex;
   align-items: center;
-  color: black;
+  color: var(--color-foreground-bold);
 }
 pre .error .code {
   display: none;
@@ -482,7 +544,7 @@ pre .inline-completions ul.dropdown li span.result-found {
 }
 pre .inline-completions ul.dropdown li span.result {
   width: 100px;
-  color: black;
+  color: var(--color-foreground-bold);
   display: inline-block;
 }
 .dark-theme .markdown pre {
@@ -515,27 +577,26 @@ pre .logger {
 }
 
 pre .logger svg {
-  margin-right:9px
+  margin-right: 9px;
 }
 
 pre .logger.error-log {
   background-color: #fee;
-  color: #ff0b0b;
-  border-left: 1px solid #bf1818
+  color: #d20000;
+  border-left: 1px solid #bf1818;
 }
 
 pre .logger.warn-log {
   background-color: #ffe;
-  border-left: 1px solid #eae662
+  border-left: 1px solid #eae662;
 }
 
 pre .logger.log-log {
   background-color: #f3f3f3;
-  border-left: 1px solid #f3f3f3
+  border-left: 1px solid #f3f3f3;
 }
 
 pre .logger.log-log svg {
   margin-left: 6px;
-  margin-right:9px
+  margin-right: 9px;
 }
-

--- a/site/src/tsconfig.json
+++ b/site/src/tsconfig.json
@@ -7,6 +7,7 @@
         "module": "esnext",
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
+        "resolveJsonModule": true,
         "strict": true,
         "noImplicitAny": false // node_modules issues
     }


### PR DESCRIPTION
Normally I'd prefer to send a separate `fix:` for the accessibility bugs and `feat:` for dark mode, but they touch a lot of the same areas of CSS colors.

For accessibility, I ran [Lighthouse (aXe) audits](https://developer.chrome.com/docs/lighthouse/accessibility/scoring) and fixed the detected WCAG AA reports:

* [Background and foreground colors have a sufficient contrast ratio](https://dequeuniversity.com/rules/axe/4.7/color-contrast):
  * Code blocks highlighted with [Shiki](https://shiki.style) now use a custom theme forked from `github-light`, with darker / more contrast-y colors in a few places
  * Relatively light grays, reds, oranges were darkened a bit
* [Heading elements appear in a sequentially-descending order](https://dequeuniversity.com/rules/axe/4.7/heading-order):
  * Some headings were switched from `h2 -> h4` / `h2 -> h5` to `h2 -> h3`
  * Other headings were switched to non-heading elements, when headings weren't necessary

For dark mode, this moves colors into CSS variables declared in `:root` with named pairs like `--color-gray-dark` and `--color-gray-light`. Those pair are each used in light mode as well as a new `@media (prefers-color-scheme: dark)` mode under an alias like `--color-border`.

<table>
<thead>
<tr>
<th>Dark Mode</th>
<th>Light Mode</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="962" height="832" alt="Dark mode screenshot of the top of the page" src="https://github.com/user-attachments/assets/30c8b2db-2be0-4062-a6fc-a418c91183ba" />
</td>
<td>
<img width="962" height="832" alt="Light mode screenshot of the top of the page" src="https://github.com/user-attachments/assets/20d28228-1f5d-405d-9b25-13dc486e6350" />
</td>
</tr>
<tr>
<td>
<img width="962" height="832" alt="Dark mode screenshot of the bottom of the page" src="https://github.com/user-attachments/assets/ee965e22-c92d-421f-8818-d912cd111021" />
</td>
<td>
<img width="962" height="832" alt="Light mode screenshot of the bottom of the page" src="https://github.com/user-attachments/assets/70259db5-a5db-4bd9-a26b-c37d1e17e113" />
</td>
</tr>
</tbody>
</table>

I opted not to add two potential good followups to this PR's scope:
* Adding a manual button to the page to toggle the color theme
* Using a dark mode theme for Shiki-highlighted code, instead of giving the code the light mode style tan background
  * This would involve more than just forking the `github-dark` theme. Because the site is pre-rendered to HTML, the Shiki theme would need to refer to CSS variables for colors. This is doable but more work.
